### PR TITLE
Enable table headers to be stickied when scrolling

### DIFF
--- a/src/components/Table/index.js
+++ b/src/components/Table/index.js
@@ -233,17 +233,10 @@ const Table = () => {
   return (
     <Container className="table">
       <ReactTooltip />
-      <ReactTable
-        align="center"
-        responsive
-        borderless
-        striped
-        hover
-        {...getTableProps()}
-      >
+      <ReactTable align="center" borderless striped hover {...getTableProps()}>
         <thead>
           {headerGroups.map(headerGroup => (
-            <tr {...headerGroup.getHeaderGroupProps()}>
+            <tr className="sticky" {...headerGroup.getHeaderGroupProps()}>
               {headerGroup.headers.map(column => (
                 <th {...column.getHeaderProps()}>
                   {column.render('Header')}

--- a/src/components/Table/styles.scss
+++ b/src/components/Table/styles.scss
@@ -7,6 +7,12 @@
     display: none;
   }
 
+  tr.sticky th {
+    background: white;
+    position: sticky;
+    top: 0;
+  }
+
   .nav-link {
     padding: 0;
   }


### PR DESCRIPTION
Referred to https://css-tricks.com/position-sticky-and-table-headers/
for help.

Fixes #18

New look when scrolling:

![Fixed Header](https://user-images.githubusercontent.com/13009507/83912556-0ca15f00-a73c-11ea-92e2-2f9a3ff3712c.gif)
