### PR TITLE
Show pattern for completed questions

### DIFF
--- a/src/components/Table/index.js
+++ b/src/components/Table/index.js
@@ -152,9 +152,17 @@ const Table = () => {
               const patterns = `${cellInfo.row.original.pattern}`
                 .split(',')
                 .map(pattern => {
+                  if (showPatterns[0] || checked[cellInfo.row.original.id]) {
+                    return (
+                      <Badge key={pattern} className={pattern} pill>
+                        {pattern}
+                      </Badge>
+                    );
+                  }
+
                   return (
                     <Badge key={pattern} className={pattern} pill>
-                      {showPatterns[0] ? pattern : '***'}
+                      ***
                     </Badge>
                   );
                 });


### PR DESCRIPTION
Patch #34 introduced toggling for questions (regardless of completion
status). This patch will show patterns when the "Show/Hide Patterns"
toggle is set to "Hide" and the respective question has been completed.

Fixes #36