### PR TITLE
Find attempted questions by difficulty

### DIFF
--- a/src/components/Table/index.js
+++ b/src/components/Table/index.js
@@ -5,7 +5,6 @@ import {
   Row,
   Badge,
   NavLink,
-  Col,
 } from 'reactstrap';
 import Toggle from 'react-toggle';
 import ReactTooltip from 'react-tooltip';

--- a/src/components/Table/index.js
+++ b/src/components/Table/index.js
@@ -5,6 +5,7 @@ import {
   Row,
   Badge,
   NavLink,
+  Col,
 } from 'reactstrap';
 import Toggle from 'react-toggle';
 import ReactTooltip from 'react-tooltip';
@@ -39,6 +40,17 @@ const Table = () => {
     checkedList = newCheckedList;
     window.localStorage.setItem('checked', JSON.stringify(checkedList));
   }
+  const data = React.useMemo(() => questions, []);
+  /* Get a list of all checked questions in the form of a dictionary keys as question difficulty */
+  const checkedQuestionsByDifficulty = { Easy: 0, Hard: 0, Medium: 0 };
+  for (let i = 0; i < checkedList.length; i += 1) {
+    if (checkedList[i]) {
+      checkedQuestionsByDifficulty[data[i].difficulty] += 1;
+    }
+  }
+  const [checkQuestionsDict, setcheckQuestionsDict] = useState(
+    checkedQuestionsByDifficulty,
+  );
 
   const [checked, setChecked] = useState(checkedList);
 
@@ -54,7 +66,8 @@ const Table = () => {
     window.localStorage.setItem('showPatterns', JSON.stringify(showPatterns));
   }, [showPatterns]);
 
-  const data = React.useMemo(() => questions, []);
+  /*To view the number of question solved by difficulty*/
+  console.log(checkQuestionsDict);
 
   const defaultColumn = React.useMemo(
     () => ({
@@ -81,6 +94,22 @@ const Table = () => {
                     checked[cellInfo.row.original.id] = !checked[
                       cellInfo.row.original.id
                     ];
+                    /*increment or decrement question count for the correct difficulty from the checkbox */
+                    if (checked[cellInfo.row.original.id]) {
+                      setcheckQuestionsDict(prevState => ({
+                        ...prevState,
+                        [cellInfo.row.original.difficulty]:
+                          prevState[cellInfo.row.original.difficulty] + 1,
+                      }));
+                    } else {
+                      setcheckQuestionsDict(prevState => ({
+                        ...prevState,
+                        [cellInfo.row.original.difficulty]:
+                          prevState[cellInfo.row.original.difficulty] === 0
+                            ? 0
+                            : prevState[cellInfo.row.original.difficulty] - 1,
+                      }));
+                    }
                     setChecked([...checked]);
                   }}
                 />


### PR DESCRIPTION
The new changes, find out the number of checked questions and group them by difficulty. Currently, it is just printing on the dev console and not on the UI. But if the logic seems correct we can go forward with that afterward.
Steps:
Firstly find the number of checked questions from the local storage and find their difficulty level and store them in a dictionary
Initialize this as our state
Then on every check box state change, we increment the corresponding difficulty value (or decrement it if check box in unchecked)
Issues #39  and #59 correspond to this.