### PR TITLE
Disable searching question by name

### DIFF
--- a/src/components/Table/index.js
+++ b/src/components/Table/index.js
@@ -183,6 +183,7 @@ const Table = () => {
                 </NavLink>
               );
             },
+            disableFilters: true,
           },
           {
             Header: 'Solutions',


### PR DESCRIPTION
This will need to be looked at again as we now have custom cell generation which doesn't play nicely with the default filtering! For now, we'll disable filtering by question name.