### PR TITLE
Fixed faulty link of the Backspace String Compare question

### DIFF
--- a/src/data/index.js
+++ b/src/data/index.js
@@ -1935,7 +1935,7 @@ const questions = [
   {
     id: 152,
     name: 'Backspace String Compare',
-    url: 'https://leetcode.com/problems/backspace-string-compare',
+    url: 'https://leetcode.com/problems/backspace-string-compare/',
     pattern: ['Two Pointers'],
     difficulty: 'Easy',
     premium: false,


### PR DESCRIPTION
I've noticed that the link to discuss for the Backspace String Compare question seems to be wrong and I've fixed it.
Please let me know if I can make any more changes or if I've done something wrong. Thanks!