### PR TITLE
add modal for reset button

### DIFF
--- a/src/components/Table/index.js
+++ b/src/components/Table/index.js
@@ -7,6 +7,9 @@ import {
   Badge,
   NavLink,
   Button,
+  Modal,
+  ModalHeader,
+  ModalFooter,
 } from 'reactstrap';
 import Toggle from 'react-toggle';
 import ReactTooltip from 'react-tooltip';
@@ -97,6 +100,14 @@ const Table = () => {
         columns: [
           {
             Header: () => {
+              /**
+               * Modal Handlers for the Reset Button
+               */
+              const [resetModal, setResetModal] = React.useState(false);
+              const toggleResetModal = () => {
+                setResetModal(!resetModal);
+              };
+
               return (
                 <span>
                   <Badge className="" pill>
@@ -148,10 +159,22 @@ const Table = () => {
                     outline
                     size="sm"
                     color="danger"
-                    onClick={resetHandler}
+                    onClick={toggleResetModal}
                   >
                     Reset
                   </Button>
+                  {/* Modal for Reset Button */}
+                  <Modal isOpen={resetModal} toggle={toggleResetModal}>
+                    <ModalHeader toggle={toggleResetModal}>
+                      Are you sure you want to reset your progress?
+                    </ModalHeader>
+                    <ModalFooter>
+                      <Button onClick={resetHandler} color="success">
+                        Reset
+                      </Button>
+                      <Button onClick={toggleResetModal}>Cancel</Button>
+                    </ModalFooter>
+                  </Modal>
                 </span>
               );
             },


### PR DESCRIPTION
Hey @seanprashad - Sorry this took a little bit, still new to the whole react eco system / web development in general.

I have the changes below - basically just a simple modal from "reactstrap" and when the "Reset" button is toggled - it changes the state to show the modal

https://user-images.githubusercontent.com/55965440/156243957-3370d813-5ddb-45ab-a345-28ffbf3f972c.mov

I originally had tried to make a separate folder under "components" for the modal + logic for it - but I found that moving the "resetHandler" was a bit more tricky than I had planned - so I opted in to just adding the state / modal directly into the "table/index.js"

- If there was a better way to do this please let me know - I'm open to all suggestions and still learning - thanks for your review on this!