### PR TITLE
Enable keep_files

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -34,3 +34,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build
+          keep_files: true


### PR DESCRIPTION
See
https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-keeping-existing-files-keep_files.
We need this because the directory with all of the content is being removed in the current Workflows.

Fixes #189