### PR TITLE
Company name appears on hover

### DIFF
--- a/src/components/Table/index.js
+++ b/src/components/Table/index.js
@@ -437,6 +437,7 @@ const Table = () => {
                     src={`${iconPath}${company.slug}.png`}
                     alt={company.name}
                     data-tip={tooltipText}
+                    title={company.name}
                   />
                 );
               });


### PR DESCRIPTION
✨When you hover over a company logo, the name of the company should appear. 

Hello! I've been using the website for a bit to track my LeetCode progress. What bothered me was when I hovered over a company logo and I didn't see the company's name. I think this would be a nice UX improvement and it'd be a quick change.

Thoughts?