### PR TITLE
Add sliding window to algorithm tips page

### DIFF
--- a/src/components/Tips/index.js
+++ b/src/components/Tips/index.js
@@ -33,6 +33,7 @@ If must solve in-place then
 
 If asked for maximum/minimum subarray/subset/options then
 - Dynamic programming
+- Sliding window
 
 If asked for top/least K items then
 - Heap


### PR DESCRIPTION
What:
I propose sliding window be added to the algorithm tips page under `maximum/minimum subarray/subset/options`.

Why:
Sliding window is a common strategy for optimal solutions to medium Leetcode problems. I've seen it come up several times as I've gone through some of the most commonly asked questions by Amazon. I like this cheat sheet of tips, and I think it would be more complete if it mentioned sliding window and when to use it.