### PR TITLE
Fix AboutPanel hydration mismatch from adjacent text nodes

### DIFF
--- a/src/components/panels/AboutPanel.tsx
+++ b/src/components/panels/AboutPanel.tsx
@@ -53,13 +53,11 @@ export default function AboutPanel() {
             <p>
               In <span className="font-semibold text-zinc-900 dark:text-zinc-100">2019</span>, as a broke college
               student who couldn&apos;t afford premium interview resources, I spent countless hours searching
-              for free materials and teaching myself React to build{" "}
-              <span className="font-semibold text-zinc-900 dark:text-zinc-100">Leetcode Patterns</span>.
+              for free materials and teaching myself React to build <span className="font-semibold text-zinc-900 dark:text-zinc-100">Leetcode Patterns</span>.
             </p>
             <p>
-              I believe <span className="font-semibold text-zinc-900 dark:text-zinc-100">everyone</span>{" "}deserves
-              access to high-quality interview material - regardless of their financial situation. It&apos;s why I chose to make this website{" "}
-              <a
+              I believe <span className="font-semibold text-zinc-900 dark:text-zinc-100">everyone</span> deserves
+              access to high-quality interview material - regardless of their financial situation. It&apos;s why I chose to make this website <a
                 href="https://github.com/seanprashad/leetcode-patterns/blob/main/LICENSE"
                 target="_blank"
                 rel="noopener noreferrer"


### PR DESCRIPTION
Fixes the recoverable hydration error reported at the `everyone`/`deserves` boundary in `AboutPanel`:

> Hydration failed because the server rendered text didn't match the client.
> `+ {" deserves access to high-quality interview material — regardless of their financia..."}`
> `- {" "}`

**Cause:** `{" "}` expressions adjacent to plain JSX text (e.g. `</span>{" "}deserves`) render as two separate DOM text nodes, which SSR delimits with `<!-- -->` markers. Anything that touches the DOM before React hydrates — translation or grammar-checker browser extensions are the usual culprits — merges or strips those nodes, and React 19's strict hydration then bails with the error above.

**Fix:** merge each `{" "}` + text pair in `AboutPanel` into a single text run (`</span> deserves`, `build <span>`, `website <a>`). The SSR output becomes one text node with no comment separators, so there's no boundary left to corrupt. Rendered text is identical — verified by diffing the served HTML before/after and exercising the panel in a headless browser with a clean console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)