### PR TITLE
Fix deploy failure after Next.js 16.3.0 upgrade

### DIFF
--- a/src/lib/sw.test.ts
+++ b/src/lib/sw.test.ts
@@ -75,7 +75,7 @@ function loadSW(mockSelf: Record<string, unknown>) {
   fn(mockSelf, mockSelf.caches, mockSelf.fetch, Response, Request);
 
   return {
-    trigger(event: string, detail: Record<string, unknown>) {
+    trigger(event: string, detail: unknown) {
       const handlers = listeners.get(event) ?? [];
       handlers.forEach((h) => h(detail));
     },


### PR DESCRIPTION
## Summary
- Widens the `trigger` helper parameter in `sw.test.ts` from `Record<string, unknown>` to `unknown`
- Fixes the Deploy to GitHub Pages failure introduced by Next.js 16.3.0 (#530), which now type-checks test files during `next build`

## Context
Next.js 16.3.0 surfaced a latent type error: `FetchEvent` is not assignable to `Record<string, unknown>` because it lacks an index signature. The test logic was always correct; only the helper typing was wrong.