### PR TITLE
Added settings keys sorting

### DIFF
--- a/src/components/questions/QuestionsTable.tsx
+++ b/src/components/questions/QuestionsTable.tsx
@@ -803,7 +803,10 @@ export default function QuestionsTable({ data, updatedDate }: { data: Question[]
   }, [syncNow]);
 
   const exportProgress = useCallback(() => {
-    const payload = { completed: [...completed], starred: [...starred], notes, solvedDates, reminders };
+    // Serialize the JSON keys in order, so that they're stable across backups
+    const settings = { completed: [...completed], starred: [...starred], notes, solvedDates, reminders };
+    const keys = Object.keys(settings).sort();
+    const payload = Object.fromEntries(keys.map((k) => [k, settings[k as keyof typeof settings]])) + "\n";
     const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");

--- a/src/components/questions/QuestionsTable.tsx
+++ b/src/components/questions/QuestionsTable.tsx
@@ -804,7 +804,7 @@ export default function QuestionsTable({ data, updatedDate }: { data: Question[]
 
   const exportProgress = useCallback(() => {
     // Serialize the JSON keys in order, so that they're stable across backups
-    const settings = { completed: [...completed], starred: [...starred], notes, solvedDates, reminders };
+    const settings = { completed: [...completed].sort(), starred: [...starred].sort(), notes, solvedDates, reminders };
     const keys = Object.keys(settings).sort();
     const payload = Object.fromEntries(keys.map((k) => [k, settings[k as keyof typeof settings]])) + "\n";
     const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });

--- a/src/components/questions/QuestionsTable.tsx
+++ b/src/components/questions/QuestionsTable.tsx
@@ -803,11 +803,8 @@ export default function QuestionsTable({ data, updatedDate }: { data: Question[]
   }, [syncNow]);
 
   const exportProgress = useCallback(() => {
-    // Serialize the JSON keys in order, so that they're stable across backups
-    const settings = { completed: [...completed].sort(), starred: [...starred].sort(), notes, solvedDates, reminders };
-    const keys = Object.keys(settings).sort();
-    const payload = Object.fromEntries(keys.map((k) => [k, settings[k as keyof typeof settings]])) + "\n";
-    const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
+    const payload = { completed: [...completed].sort((a, b) => a - b), starred: [...starred].sort((a, b) => a - b), notes, solvedDates, reminders };
+    const blob = new Blob([JSON.stringify(payload, null, 2) + "\n"], { type: "application/json" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;


### PR DESCRIPTION
I'm using Git to store my progress in dotfiles and share them between several hosts.
Sometimes, on different hosts, I'm getting the keys in json in a different order.
This makes it difficult to understand exactly what was changed (while in reality, it could be just one line), and also makes diffs larger.
As a solution, I suggest always sort the keys of the settings object.

(the idea is the same as I proposed in https://github.com/philc/vimium/pull/4764)